### PR TITLE
Make strings straightforward and simple

### DIFF
--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -16,6 +16,6 @@
 -->
 <resources xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
     <!-- Sim recents -->
-    <string name="recents_multiwin_nolastapp">You removed all recents, please choose an app from launcher or drawer.</string>
-    <string name="recents_killapp_warning">Please long press to kill app</string>
+    <string name="recents_multiwin_nolastapp">All apps have been terminated</string>
+    <string name="recents_killapp_warning">Long press to terminate app</string>
 </resources>


### PR DESCRIPTION
* We don't need to tell people please. This is common sense
* "Recents" should not be used to defer to an application. They are not the same
* Replace kill with terminate. It looks cool, and something has to take up the extra space